### PR TITLE
[cannot_determine_the_AWS_Profile]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # aws-python-s3-app
 Python application which uses IAM role to put objects inside an S3 bucket.
 
-Update the `conf.ini` with the correct IAM role ARN and the name of the bucket to write to.
+Update the `config.ini` with the correct IAM role ARN and the name of the bucket to write to.
 Details on how to create the role are described in [this tutorial](https://medium.com/@lvthillo/connect-on-premise-python-application-with-aws-services-using-roles-8b24ab4872e6).
 
 ### Start application

--- a/app.py
+++ b/app.py
@@ -44,9 +44,22 @@ def upload_file():
 
 
 def put_in_s3(filename, data):
+
+    # determine the "AWS Profile", there are three options:
+    # 1. the value is taken from ['AWS']['Profile'] or
+    # 2. ...from ['DEFAULT']['Profile'] or
+    # 3. ...from an ~/.aws/credentials [default]
+
+    if True == config.has_option('AWS', 'Profile'):
+      profile = config['AWS']['Profile']
+    elif False == config.has_option('DEFAULT', 'Profile'):
+      profile = 'default'
+
     # create an STS client object that represents a live connection to the
     # STS service
-    sts_client = boto3.client('sts')
+
+    sts_session = boto3.Session(profile_name=profile)
+    sts_client = sts_session.client('sts')
 
     # Call the assume_role method of the STSConnection object and pass the role
     # ARN and a role session name.

--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,4 @@
 [AWS]
 RoleArn = arn:aws:iam::123456789012:role/application-role
 BucketName = demo-lvthillo-bucket
+Profile = demo-profile


### PR DESCRIPTION
- the possibility to set the AWS Profile was added
- `conf.ini` changed to `config.ini` in the README.md